### PR TITLE
Add semicolon to address concatenation issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,4 +25,4 @@ return function(input, fun /*, valist: funVar */) {
   else 
     return m[fun];
 }
-})
+});


### PR DESCRIPTION
Proposing this because it was causing an issue in our build: basically if this is concatenated to a file that starts with `(` then it tries to invoke it.
